### PR TITLE
Migrate this project to the vanity URL

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,9 +15,9 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
-      - -X github.com/FollowTheProcess/git-rekt/internal/cli.version={{.Version}}
-      - -X github.com/FollowTheProcess/git-rekt/internal/cli.commit={{.Commit}}
-      - -X github.com/FollowTheProcess/git-rekt/internal/cli.buildDate={{.Date}}
+      - -X go.followtheprocess.codes/git-rekt/internal/cli.version={{.Version}}
+      - -X go.followtheprocess.codes/git-rekt/internal/cli.commit={{.Commit}}
+      - -X go.followtheprocess.codes/git-rekt/internal/cli.buildDate={{.Date}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An profoundly unhelpful git extension, try it and see!
 Compiled binaries for all supported platforms can be found in the [GitHub release]. There is also a [homebrew] tap:
 
 ```shell
-brew install FollowTheProcess/tap/git-rekt
+brew install --cask FollowTheProcess/tap/git-rekt
 ```
 
 ## Quickstart

--- a/cmd/git-rekt/main.go
+++ b/cmd/git-rekt/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/FollowTheProcess/git-rekt/internal/cli"
+	"go.followtheprocess.codes/git-rekt/internal/cli"
 	"go.followtheprocess.codes/msg"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/FollowTheProcess/git-rekt
+module go.followtheprocess.codes/git-rekt
 
 go 1.24
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/FollowTheProcess/git-rekt/internal/insults"
 	"go.followtheprocess.codes/cli"
+	"go.followtheprocess.codes/git-rekt/internal/insults"
 )
 
 // These are all set at compile time.


### PR DESCRIPTION
# Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Mainly for consistency as you obviously can't call this from Go code, but `go install go.followtheprocess.codes/git-rekt@latest` should work
